### PR TITLE
Format logger timestamp with Moment

### DIFF
--- a/frontend/test_helpers/test_bootstrap.js
+++ b/frontend/test_helpers/test_bootstrap.js
@@ -30,7 +30,9 @@ import { JSDOM } from 'jsdom';
 import chai from 'chai';
 import chaiImmutable from 'chai-immutable';
 
-const { window } = new JSDOM('<!doctype html><html><body></body></html>');
+const { window } = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'https://foo.bar'
+});
 const { document } = window;
 
 global.document = document;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4691,6 +4691,11 @@
         }
       }
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lodash": "^4.17.4",
     "marc-record-js": "^0.3.2",
     "marc-record-serializers": "^1.4.0",
+    "moment": "^2.22.2",
     "node-uuid": "^1.4.8",
     "winston": "^2.4.0",
     "xml2js": "^0.4.19"

--- a/server/logger.js
+++ b/server/logger.js
@@ -25,6 +25,7 @@
 * for the JavaScript code in this file.
 *
 */
+import moment from 'moment';
 import winston from 'winston';
 import expressWinstonLogger from 'express-winston';
 
@@ -33,7 +34,7 @@ const LOGLEVEL = process.env.NODE_ENV == 'debug' ? 'debug' : 'info';
 export const logger = new (winston.Logger)({
   transports: [
     new (winston.transports.Console)({
-      'timestamp':true, 
+      'timestamp': () => moment().format(),
       'level': LOGLEVEL
     })
   ]
@@ -42,7 +43,7 @@ export const logger = new (winston.Logger)({
 export const expressWinston = expressWinstonLogger.logger({
   transports: [
     new winston.transports.Console({
-      'timestamp':true, 
+      'timestamp': () => moment().format(),
       'level': LOGLEVEL
     })
   ],


### PR DESCRIPTION
Format logger timestamp with Moment. Otherwise the timestamp will be incorrect in Docker (Event with localtime mounted).