### PR TITLE
Add include_nonmono to loadRecord default options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@natlibfi/melinda-ui-commons",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/melinda-io-service.js
+++ b/server/melinda-io-service.js
@@ -30,7 +30,8 @@ import _ from 'lodash';
 import HttpStatus from 'http-status-codes';
 
 const DEFAULT_LOAD_OPTIONS = {
-  include_parent: 1
+  include_parent: 1,
+  include_nonmono: 1
 };
 
 export function loadRecord(client, recordId, opts) {


### PR DESCRIPTION
melinda-api-legacy was updated to return component records only for mono hosts by default:
https://github.com/NatLibFi/melinda-api-legacy/commit/6e20503df16998de5e9c8bed1cbc732e451e1097

This update add include_nonmono -parameter to default parameters for loading record and its component records , so that all component records for all types of hosts are loaded.