### PR TITLE
Handle fetch failurues and rename editor buttons

### DIFF
--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -3,7 +3,8 @@ export async function doRestCall({
   method = undefined,
   body = undefined,
   contentType = undefined,
-  resultAsJson = false
+  resultAsJson = false,
+  failureResult = undefined
 }) {
 
   const headers = {
@@ -31,6 +32,6 @@ export async function doRestCall({
   }
   catch (error) {
     console.error('fetch() failed', error);
-    return undefined;
+    return failureResult;
   }
 }

--- a/src/scripts/common.js
+++ b/src/scripts/common.js
@@ -11,18 +11,26 @@ export async function doRestCall({
     ...contentType ? {'Content-Type': contentType} : {}
   };
 
-  const result = await fetch(
-    url,
-    {
-      method,
-      headers,
-      ...body ? {body} : {}
+  try {
+    const result = await fetch(
+      url,
+      {
+        method,
+        headers,
+        ...body ? {body} : {}
+      }
+    );
+
+    if (result.ok) {
+      if (resultAsJson) {
+        return result.json();
+      }
+      return result;
     }
-  );
-
-  if (resultAsJson) {
-    return result.json();
+    throw new Error(result.status);
   }
-
-  return result;
+  catch (error) {
+    console.error('fetch() failed', error);
+    return undefined;
+  }
 }

--- a/src/views/partials/editorButtons.hbs
+++ b/src/views/partials/editorButtons.hbs
@@ -5,14 +5,14 @@
 <!-- This is the default editor row. Work in progress... Currently onclick etc should be implemented in the app code... -->
 <!-- By default, this block is hidden (display none (vs flex). I make it visible only when there's an editable record. -->
 <div id="editorButtons" style="display: none; width: 100%;">
-    <button id="addNewRowAbove" class="alternate-blue tooltip" tooltip-text="Lisää rivi aktiivisen rivin yläpuolelle">
-        <span class="material-symbols-outlined">add_row_above</span> Lisää rivi ylle
+    <button id="addNewRowAbove" class="alternate-blue tooltip" tooltip-text="Lisää kenttä aktiivisen kentän yläpuolelle">
+        <span class="material-symbols-outlined">add_row_above</span> Lisää kenttä ylle
     </button>
-    <button id="addNewRowBelow" class="alternate-blue tooltip" tooltip-text="Lisää rivi aktiivisen rivin alapuolelle">
-        <span class="material-symbols-outlined">add_row_below</span> Lisää rivi alle
+    <button id="addNewRowBelow" class="alternate-blue tooltip" tooltip-text="Lisää kenttä aktiivisen kentän alapuolelle">
+        <span class="material-symbols-outlined">add_row_below</span> Lisää kenttä alle
     </button>
-    <button id="removeActiveRow" class="alternate-blue tooltip" tooltip-text="Poista aktiivinen rivi">
-        <span class="material-symbols-outlined">variable_remove</span> Poista aktiivinen rivi
+    <button id="removeActiveRow" class="alternate-blue tooltip" tooltip-text="Poista aktiivinen kenttä">
+        <span class="material-symbols-outlined">variable_remove</span> Poista aktiivinen kenttä
     </button>
     <button class="alternate-red" id="cancelEditButton" onclick="return cancelEdit(event)">
         <span class="material-symbols-outlined">cancel</span> Sulje tallentamatta


### PR DESCRIPTION
- add try {} catch {} block around fetch() to handle failures
- also add default value for failures (eg. failure to perform "get records" styled operation can now return an empty array)
- rename editor buttons: s/rivi/kenttä/