### PR TITLE
Editor4

### DIFF
--- a/src/scripts/editorUtils.js
+++ b/src/scripts/editorUtils.js
@@ -297,7 +297,8 @@ export function stringToMarcField(str, subfieldCodePrefix = '$$') { // export si
 
     const rest = str.substring(5);
     if (!isDataFieldTag(tag)) {
-      return {tag, ind1, ind2, value: rest.replace(/#/gu, ' '), error: rest.length <= 5 ? `Incomplete field ${tag}` : false};
+      // Should we check tag-specific control field lengths here? (eg. 008 is always 40 chars etc)
+      return {tag, ind1, ind2, value: rest.replace(/#/gu, ' '), error: rest.length == 0 ? `Control field ${tag} contains no data` : false};
     }
 
     const {subfields, error} = convertDataToSubfields(tag, rest, subfieldCodePrefix);

--- a/src/scripts/editorUtils.js
+++ b/src/scripts/editorUtils.js
@@ -277,7 +277,7 @@ export function undoMarkAllFieldsUneditable(settings) {
 }
 
 export function stringToMarcField(str, subfieldCodePrefix = '$$') { // export since used in tests. settings.subfieldCodePrefix
-    // console.log(`String2field: '${str}', '${subfieldCodePrefix}'`);
+    console.log(`String2field: '${str}', '${subfieldCodePrefix}'`);
     const len = str.length;
     if (len <= 3) {
       return {tag: str, error: `Incomplete field ${str}`};
@@ -301,13 +301,16 @@ export function stringToMarcField(str, subfieldCodePrefix = '$$') { // export si
     }
 
     const {subfields, error} = convertDataToSubfields(tag, rest, subfieldCodePrefix);
+    const tagAndError = error ? `${tag}: ${error}` : error;
     //if (subfields.length === 0) {
-    if (error) {
+    console.log(`TAG='${tag}'`);
+
+    if (subfields.length === 0) {
       //console.log(`Failed to parse '${str}': ${error}`);
-      return {tag, ind1, ind2, value: rest, error: `${tag}: ${error}`}; // This is erronous state, as subfields failed to parse
+      return {tag, ind1, ind2, value: rest, error: tagAndError}; // This is erronous state, as subfields failed to parse
     }
 
-    return {tag, ind1, ind2, subfields, error: false};
+    return {tag, ind1, ind2, subfields, error: tagAndError};
 
     function normalizeIndicator(ind, tag) { // convert data from web page to marc
       //console.log(`Process indicator '${ind}'`);
@@ -335,26 +338,30 @@ function convertDataToSubfields(tag, data, separator = '$$') {
       return {subfields: [], error: `Data segment should begin with '${separator}'`};
     }
     const data2 = data.substring(separator.length);
-    const subfields = data2.split(separator);
+    const subfieldStrings = data2.split(separator);
 
-    const noSubfieldCodeIndex = subfields.findIndex((sf, i) => sf.length < 1); // 1st char is code and the rest is data
+    const noSubfieldCodeIndex = subfieldStrings.findIndex((sf, i) => sf.length < 1); // 1st char is code and the rest is data
     if (noSubfieldCodeIndex > -1) {
       return{subfields: [], error: `Subfield #${noSubfieldCodeIndex+1} does not contain a subfield code (nor data)`};
     }
 
-    const illegalSubfieldCodeIndex = subfields.findIndex((sf, i) => sf.match(/^[^a-z0-9]/u));
+    const illegalSubfieldCodeIndex = subfieldStrings.findIndex((sf, i) => sf.match(/^[^a-z0-9]/u));
     if (illegalSubfieldCodeIndex > -1) {
-      return {subfields: [], error: `Subfield #${illegalSubfieldCodeIndex+1} has unexpected subfield code '${subfields[illegalSubfieldCodeIndex].substring(0, 1)}'`};
+      return {subfields: [], error: `Subfield #${illegalSubfieldCodeIndex+1} has unexpected subfield code '${subfieldStrings[illegalSubfieldCodeIndex].substring(0, 1)}'`};
     }
 
     if (tag !== 'CAT') { // CAT's empty $b is so common, that there's no point to complain about it, esp. as it is oft uneditable.
-      const emptySubfieldIndex = subfields.findIndex((sf, i) => sf.length < 2); // 1st char is code and the rest is data
+      const emptySubfieldIndex = subfieldStrings.findIndex((sf, i) => sf.length < 2); // 1st char is code and the rest is data
       if (emptySubfieldIndex > -1) {
-        return{subfields: [], error: `Subfield #${emptySubfieldIndex+1} (${separator}${subfields[emptySubfieldIndex].substring(0, 1)}) does not contain any data`};
+        return{subfields: [], error: `Subfield #${emptySubfieldIndex+1} (${separator}${subfieldStrings[emptySubfieldIndex].substring(0, 1)}) does not contain any data`};
       }
     }
 
-    return { subfields: subfields.map(sf => stringToSubfield(sf)), error: undefined};
+    const subfields = subfieldStrings.map(str => stringToSubfield(str));
+    if (tag === 'TAG') { // Added row that has not been renamed
+      return { subfields: subfields, error: `Illegal tag name`};
+    }
+    return { subfields: subfields, error: false};
 
     function stringToSubfield(str) {
       return {'code': str.substring(0, 1), 'value': str.substring(1)};

--- a/src/scripts/marcRecordUi.js
+++ b/src/scripts/marcRecordUi.js
@@ -159,7 +159,7 @@ function getNonRepeatableDuplicateErrors(fields, tags, result = []) {
 
   function normalizeTag(tag) {
     if (tag.length == 1) { // '1' => '1XX'
-      return normalizeTag`${tag}XX`;
+      return `${tag}XX`;
     }
     return tag;
   }

--- a/tests/testFixtures/validate/01/metadata.json
+++ b/tests/testFixtures/validate/01/metadata.json
@@ -1,7 +1,7 @@
 {
-  "description": "01: valid field",
-  "input": "500##$$foo",
-  "error": false,
+  "description": "01: valid fields",
+  "input": ["001  123456789", "500##$$foo", "700##$$aJoku nimi"],
+  "errors": [],
   "only": false,
   "decorator": {
     "subfieldCodePrefix": "$$"

--- a/tests/testFixtures/validate/01/metadata.json
+++ b/tests/testFixtures/validate/01/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "01: validd field",
+  "description": "01: valid field",
   "input": "500##$$foo",
   "error": false,
   "only": false,

--- a/tests/testFixtures/validate/02/metadata.json
+++ b/tests/testFixtures/validate/02/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "02:_validate field: no data",
+  "description": "02: validate field: no data",
   "input": "500##$$foo$$b",
   "error": "500: Subfield #2 ($$b) does not contain any data",
   "only": false,

--- a/tests/testFixtures/validate/02/metadata.json
+++ b/tests/testFixtures/validate/02/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "02: validate field: no data",
-  "input": "500##$$foo$$b",
-  "error": "500: Subfield #2 ($$b) does not contain any data",
+  "input": ["500##$$foo$$b"],
+  "errors": ["500: Subfield #2 ($$b) does not contain any data"],
   "only": false,
   "decorator": {
     "subfieldCodePrefix": "$$"

--- a/tests/testFixtures/validate/03/metadata.json
+++ b/tests/testFixtures/validate/03/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "03 validate field content",
-  "input": "600## |foo$ |Bcontent",
-  "error": "600: Subfield #2 has unexpected subfield code 'B'",
+  "input": ["600## |foo$ |Bcontent"],
+  "errors": ["600: Subfield #2 has unexpected subfield code 'B'"],
   "only": false,
   "decorator": {
     "subfieldCodePrefix": " |"

--- a/tests/testFixtures/validate/04/metadata.json
+++ b/tests/testFixtures/validate/04/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "04 validate field: first subfield does not start where it ought to",
-  "input": "700##aaa|foo|Bcontent",
-  "error": "700: Data segment should begin with '|'",
+  "input": ["700##aaa|foo|Bcontent"],
+  "errors": ["700: Data segment should begin with '|'"],
   "only": false,
   "decorator": {
     "subfieldCodePrefix": "|"

--- a/tests/testFixtures/validate/05/metadata.json
+++ b/tests/testFixtures/validate/05/metadata.json
@@ -1,0 +1,9 @@
+{
+  "description": "04 validate field: first subfield does not start where it ought to",
+  "input": ["001  123456789", "001  666", "245##$aNimeke."],
+  "errors": ["Non-repeatable 001 appears more than once!"],
+  "only": false,
+  "decorator": {
+    "subfieldCodePrefix": "$"
+  }
+}

--- a/tests/validateField.spec.js
+++ b/tests/validateField.spec.js
@@ -6,7 +6,6 @@ const {default: generateTests} = fixugen;
 
 
 import {stringToMarcField} from '../src/scripts/editorUtils.js';
-import {filterField} from '../src/scripts/marcRecordUi.js';
 
 import {JSDOM} from 'jsdom';
 

--- a/tests/validateField.spec.js
+++ b/tests/validateField.spec.js
@@ -4,10 +4,8 @@ import {READERS} from '@natlibfi/fixura';
 import fixugen from '@natlibfi/fixugen';
 const {default: generateTests} = fixugen;
 
-
 import {stringToMarcField} from '../src/scripts/editorUtils.js';
-
-import {JSDOM} from 'jsdom';
+import {extractErrors} from '../src/scripts/marcRecordUi.js';
 
 
 describe('html div->json field ', () => {
@@ -22,22 +20,10 @@ describe('html div->json field ', () => {
     }
   });
 
-  function callback({getFixture, field, error, input, decorator = {}}) {
-    const targetJson = field; // JSON.parse(getFixture('field.json'));
-    //console.log(JSON.stringify(inputField));
-    const inputHtml = `<!DOCTYPE html><div id="editor">${getFixture('target.html')}</div>`.replace(/\n/gu, '');
-    //console.log(inputHtml);
-    //const dom = new JSDOM('<!DOCTYPE html><div id="editor"></div>');
-    const dom = new JSDOM(inputHtml);
-    const document = dom.window.document;
-
-    const elem = document.getElementById('editor');
-    //const textContent = elem.textContent;
-    const outputJson = stringToMarcField(input, decorator.subfieldCodePrefix);
-    const realError = outputJson.error;
-    //console.log(realError);
-    expect(realError).to.eql(error);
-
+  function callback({errors, input, decorator = {}}) {
+    const fields = input.map(str => stringToMarcField(str, decorator.subfieldCodePrefix));
+    const actualErrors = extractErrors({}, fields);
+    expect(actualErrors).to.have.same.deep.members(errors);
   }
 
 });


### PR DESCRIPTION
- New editor fields syntax check: reject 'TAG' tag
- New editor fields syntax check: reject non-repeatable fields (001, 003, 008). This extends the old paradigm where we looked only for field-internal errors
- change test logic for 'validate': support multiple input field strings and output errors (previous we had one input field string and one error)